### PR TITLE
Precompute more things (again), and fix loop exit condition

### DIFF
--- a/Scala/n-body/nbody.scala
+++ b/Scala/n-body/nbody.scala
@@ -73,7 +73,7 @@ class JovianSystem() extends NBodySystem {
       mass = 5.15138902046611451e-05 * SOLAR_MASS
     )
 
-    val allBodies = List(sun, jupiter, saturn, uranus, neptune)
+    val allBodies = Array(sun, jupiter, saturn, uranus, neptune)
 
     for {
       body <- allBodies
@@ -89,7 +89,7 @@ class JovianSystem() extends NBodySystem {
 
 abstract class NBodySystem {
   import NBodySystem._
-  protected def bodies: Seq[Body]
+  protected def bodies: Array[Body]
 
   def energy: Double = {
     def energyBetween(left: Body, right: Body): Double = {
@@ -126,8 +126,9 @@ abstract class NBodySystem {
         val dy = body.y - other.y
         val dz = body.z - other.z
 
-        val distance = sqrt(dx * dx + dy * dy + dz * dz)
-        val mag = dt / (distance * distance * distance)
+        val distanceSquared = dx * dx + dy * dy + dz * dz
+        val distance = sqrt(distanceSquared)
+        val mag = dt / (distanceSquared * distance)
 
         body.advance(dx, dy, dz, -other.mass * mag)
         other.advance(dx, dy, dz, body.mass * mag)


### PR DESCRIPTION
~2.5× improvement:

~~~ text
Name, Package (J), CPU (J), GPU (J), DRAM(J), Time (ms)
k-nucleotide-warmup, 365.906, 0.000, -1.000, 94.797, 6583.941
k-nucleotide-warmup, 345.867, 0.000, -1.000, 84.117, 5663.691
k-nucleotide-warmup, 269.527, 0.000, -1.000, 65.328, 4359.938
k-nucleotide-warmup, 297.598, 0.000, -1.000, 73.891, 5228.914
k-nucleotide-warmup, 277.211, 0.000, -1.000, 65.680, 4564.380
k-nucleotide, 304.859, 0.000, -1.000, 75.266, 5425.619
k-nucleotide, 271.070, 0.000, -1.000, 65.266, 4418.162
k-nucleotide, 263.684, 0.000, -1.000, 62.883, 4247.149
k-nucleotide, 267.063, 0.000, -1.000, 63.102, 4329.866
k-nucleotide, 262.043, 0.000, -1.000, 62.563, 4189.830
k-nucleotide, 269.336, 0.000, -1.000, 65.063, 4409.423
k-nucleotide, 278.523, 0.000, -1.000, 68.391, 4707.741
k-nucleotide, 286.938, 0.000, -1.000, 70.875, 4971.702
~~~